### PR TITLE
whole api refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 -include version.mk
 
 # set build utilities 
-CXX := g++
+CXX := clang++-3.6
 AR := ar
 MKDIR := mkdir
 PY:=python
@@ -46,7 +46,7 @@ DBG_OBJS = $(OBJ-y:%=$(DBG_OBJ_CACHE)/%.do)
 REL_OBJS = $(OBJ-y:%=$(REL_OBJ_CACHE)/%.o)
 
 .PHONY = $(PHONY)
-.SILENT : $(SILENT)
+#.SILENT : $(SILENT)
 
 PHONY= all clean debug release utest
 

--- a/core/MediaStream.cpp
+++ b/core/MediaStream.cpp
@@ -17,14 +17,8 @@
 
 namespace MediaPipe {
 
-MediaContext::MediaContext(){ };
-MediaContext::~MediaContext(){ };
-
 MediaStream::MediaStream(void){ }
 MediaStream::~MediaStream(void){ }
-
-MediaStream::Serializable::Serializable() { };
-MediaStream::Serializable::~Serializable() { };
 
 
 MediaFileStream::MediaFileStream(const char* fname)
@@ -58,7 +52,7 @@ int MediaFileStream::close()
 	return ::close(fd);
 }
 
-ssize_t MediaFileStream::read(uint8_t* rb, size_t sz)
+ssize_t MediaFileStream::read(uint8_t* rb, size_t sz) const
 {
 	if(fd < 0)
 	{

--- a/mpipe.h
+++ b/mpipe.h
@@ -8,7 +8,13 @@
 #ifndef MPIPE_H_
 #define MPIPE_H_
 
+#ifdef __cplusplus
 
+#undef offsetof
+#undef container_of
+
+
+#endif
 
 
 #endif /* MPIPE_H_ */

--- a/mpipe.h
+++ b/mpipe.h
@@ -8,13 +8,30 @@
 #ifndef MPIPE_H_
 #define MPIPE_H_
 
-#ifdef __cplusplus
-
-#undef offsetof
-#undef container_of
 
 
-#endif
+namespace MediaPipe {
+
+template <class T>
+class Iterator {
+public:
+	Iterator(){};
+	virtual ~Iterator() {};
+	virtual bool hasNext() = 0;
+	virtual T* next() = 0;
+	virtual void remove() = 0;
+};
+
+template <class T>
+class Iterable {
+public:
+	Iterable(){};
+	virtual ~Iterable() {};
+	virtual Iterator<T>* iterator() = 0;
+};
+
+
+}
 
 
 #endif /* MPIPE_H_ */

--- a/rtmp/AMF0.cpp
+++ b/rtmp/AMF0.cpp
@@ -5,44 +5,393 @@
  *      Author: innocentevil
  */
 
+
+#include "cdsl_slist.h"
+#include "mpipe.h"
 #include "AMF0.h"
-#include "cdsl_dlist.h"
+#include "FLVTag.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+
+typedef struct {
+	uint8_t _[3];
+}__attribute__((packed)) uint24_t;
+
+struct amf0_str {
+	uint16_t 		len;
+	char			str_seq;
+} __attribute__((packed));
+
+struct amf0_obj_prop {
+	amf0_str 		name;
+	uint8_t			amf0_v;
+} __attribute__((packed));
+
+struct amf0_obj_end {
+	uint24_t		end_marker;
+}__attribute__((packed));
+
+struct amf0_obj {
+	amf0_obj_prop	props;		// array of amf0_obj_prop
+	// obj_end marker will follow at the end of array
+}__attribute__((packed));
+
+struct amf0_ecma_array {
+	uint32_t 		len;
+	amf0_obj_prop	props;		// array of amf0_obj_prop
+	// obj_end marker will follow at the end of array
+}__attribute__((packed));
+
+struct amf0_strict_array {
+	uint32_t		len;
+	amf0_obj_prop	props;
+}__attribute__((packed));
+
+struct amf0_date {
+	double 	epoch_mills;
+	int16_t	utc_adj;
+}__attribute__((packed));
+
+
+struct amf0_lstr {
+	uint32_t		len;
+	char			str_seq;
+}__attribute__((packed));
+
+struct amf0_val {
+	uint8_t marker;
+	union {
+		double numv;
+		uint8_t boolv;
+		struct amf0_str strv;
+	} __attribute__((packed));
+} __attribute__((packed));
 
 namespace MediaPipe {
 
-AMF0::AMF0Object::AMF0Object() {
-	cdsl_dlistInit(&list_node);
+AMF0::AMF0Base::AMF0Base()
+{
+	cdsl_slistNodeInit(this);
 }
 
-AMF0::AMF0Object::~AMF0Object() {
-}
-
-AMF0::AMF0() {
+AMF0::AMF0Base::~AMF0Base()
+{
 
 }
 
-AMF0::~AMF0() {
+
+AMF0::Iterator::Iterator(AMF0* amf)
+{
+	cdsl_slistIterInit(&amf->mutable_lentry,this);
 }
 
-void AMF0::add(AMF0Object* obj) {
+AMF0::Iterator::~Iterator(){ }
+
+bool AMF0::Iterator::hasNext()
+{
+	return cdsl_slistIterHasNext(this);
 }
 
-int AMF0::lenght(void) {
+AMF0::AMF0Base* AMF0::Iterator::getNext()
+{
+	return (AMF0::AMF0Base*) cdsl_slistIterNext(this);
 }
 
-AMF0::AMF0Object* AMF0::remove(int idx) {
+void AMF0::Iterator::remove()
+{
+	cdsl_slistIterRemove(this);
 }
 
-void AMF0::remove(AMF0Object* obj) {
+AMF0::AMF0()
+{
+	cdsl_slistEntryInit(&immutable_lentry);
+	cdsl_slistEntryInit(&mutable_lentry);
+	iter = new Iterator(this);
+}
+
+AMF0::~AMF0()
+{
+	while(!cdsl_slistIsEmpty(&immutable_lentry))
+	{
+	}
+}
+
+ssize_t AMF0::serialize(MediaContext* ctx, MediaStream* stream)
+{
+
+}
+
+ssize_t AMF0::deserialize(MediaContext* ctx, MediaStream* stream)
+{
+	if(!stream)
+		return -1;
+	AMF0::AMF0Base* val = NULL;
+	AMF0::AMF0Type type;
+	FLVTag* flv_t = (FLVTag*) ctx;
+	size_t t_sz = flv_t->getSize();
+	size_t sz = 0;
+	while(sz < t_sz)
+	{
+		if(stream->read((uint8_t*) &type, sizeof(uint8_t)) < 0)
+			return sz;
+		sz++;
+		switch(type){
+		case NUMBER:
+			val = (AMF0::AMF0Base*)  new AMF0NumberData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case BOOLEAN:
+			val = (AMF0::AMF0Base*) new AMF0BooleanData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case STRING:
+			val = (AMF0::AMF0Base*) new AMF0StringData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case OBJECT:
+			val = (AMF0::AMF0Base*) new AMF0ObjectData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case REF:
+			val = (AMF0::AMF0Base*) new AMF0ReferenceData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case ECMA_ARRAY:
+			val = (AMF0::AMF0Base*) new AMF0ECMAArrayData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case OBJ_END:
+			// object end is not handled here
+			break;
+		case UND:
+			break;
+		case NUL:
+			break;
+		case MV_CLIP:
+			break;
+		case STRICT_ARRAY:
+			val = (AMF0::AMF0Base*) new AMF0StrictArrayData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case DATE:
+			val = (AMF0::AMF0Base*) new AMF0DateData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		case LSTRING:
+			val = (AMF0::AMF0Base*) new AMF0LongStringData();
+			sz += val->deserialize(ctx, stream);
+			break;
+		}
+		cdsl_slistPutTail(&immutable_lentry,val);
+	}
+	return sz;
+}
+
+ssize_t AMF0::read(uint8_t* data)
+{
+
+}
+
+
+
+int AMF0::add(AMF0Base* obj)
+{
+	return cdsl_slistPutTail(&mutable_lentry,obj);
+}
+
+void AMF0::remove(AMF0Base* obj)
+{
+	cdsl_slistRemove(&mutable_lentry, obj);
+}
+
+int AMF0::length(void)
+{
+	return cdsl_slistSize(&mutable_lentry) + cdsl_slistSize(&immutable_lentry);
+}
+
+AMF0NumberData::AMF0NumberData() {
+	val = 0.0;
+}
+
+AMF0NumberData::~AMF0NumberData() {
+}
+
+ssize_t AMF0NumberData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0NumberData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+double AMF0NumberData::getValue() {
+}
+
+AMF0::AMF0Type AMF0NumberData::getType() {
+}
+
+AMF0BooleanData::AMF0BooleanData() {
+	val = false;
+}
+
+AMF0BooleanData::~AMF0BooleanData() {
+
+}
+
+ssize_t AMF0BooleanData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+	::printf("bool serialized\n");
+}
+
+ssize_t AMF0BooleanData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0BooleanData::getType() {
+}
+
+bool AMF0BooleanData::getValue() {
+}
+
+AMF0StringData::AMF0StringData() {
+}
+
+AMF0StringData::~AMF0StringData() {
+}
+
+ssize_t AMF0StringData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0StringData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0StringData::getType() {
+}
+
+const std::string* AMF0StringData::getValue() {
+}
+
+AMF0ObjectData::AMF0ObjectData() {
+}
+
+AMF0ObjectData::~AMF0ObjectData() {
+}
+
+ssize_t AMF0ObjectData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0ObjectData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0ObjectData::getType() {
+}
+
+const AMF0* AMF0ObjectData::getValue() {
+}
+
+AMF0ReferenceData::AMF0ReferenceData() {
+}
+
+AMF0ReferenceData::~AMF0ReferenceData() {
+}
+
+ssize_t AMF0ReferenceData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0ReferenceData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0ReferenceData::getType() {
+}
+
+uint16_t AMF0ReferenceData::getValue() {
+}
+
+AMF0ECMAArrayData::AMF0ECMAArrayData() {
+}
+
+AMF0ECMAArrayData::~AMF0ECMAArrayData() {
+}
+
+ssize_t AMF0ECMAArrayData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0ECMAArrayData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0ECMAArrayData::getType() {
+}
+
+const AMF0* AMF0ECMAArrayData::getValue() {
+}
+
+AMF0StrictArrayData::AMF0StrictArrayData() {
+}
+
+AMF0StrictArrayData::~AMF0StrictArrayData() {
+}
+
+ssize_t AMF0StrictArrayData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0StrictArrayData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0StrictArrayData::getType() {
+}
+
+const AMF0* AMF0StrictArrayData::getValue() {
+}
+
+AMF0DateData::AMF0DateData() {
+}
+
+AMF0DateData::~AMF0DateData() {
+}
+
+ssize_t AMF0DateData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0DateData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0DateData::getType() {
+}
+
+time_t AMF0DateData::getValue() {
+}
+
+AMF0LongStringData::AMF0LongStringData() {
+}
+
+AMF0LongStringData::~AMF0LongStringData() {
+}
+
+ssize_t AMF0LongStringData::serialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+ssize_t AMF0LongStringData::deserialize(MediaContext* ctx,
+		MediaStream* stream) {
+}
+
+AMF0::AMF0Type AMF0LongStringData::getType() {
+}
+
+const std::string* AMF0LongStringData::getValue() {
 }
 
 } /* namespace MediaPipe */
-
-ssize_t MediaPipe::AMF0::read(uint8_t* data) {
-}
-
-ssize_t MediaPipe::AMF0::serialize(MediaContext* meta, MediaStream* stream) {
-}
-
-ssize_t MediaPipe::AMF0::deserialize(MediaContext* meta, MediaStream* stream) {
-}

--- a/rtmp/AMF0.h
+++ b/rtmp/AMF0.h
@@ -9,37 +9,178 @@
 #ifndef RTMP_AMF0_H_
 #define RTMP_AMF0_H_
 
+#include <string>
+#include <stdint.h>
 #include "core/MediaStream.h"
-#include "cdsl_dlist.h"
+#include "cdsl_slist.h"
 
 namespace MediaPipe {
 
 class AMF0 : MediaStream::Serializable {
 public:
-	class AMF0Object : MediaStream::Serializable {
+	typedef enum {
+		NUMBER = 0,
+		BOOLEAN = 1,
+		STRING = 2,
+		OBJECT = 3,
+		MV_CLIP = 4,
+		NUL = 5,
+		UND = 6,
+		REF = 7,
+		ECMA_ARRAY = 8,
+		OBJ_END = 9,
+		STRICT_ARRAY = 10,
+		DATE = 11,
+		LSTRING = 12
+	}AMF0Type;
+
+	class AMF0Base : MediaStream::Serializable ,slistNode_t{
+		friend class AMF0;
 	public:
-		AMF0Object();
-		virtual ~AMF0Object();
-		virtual size_t getSize(void) = 0;
-		virtual ssize_t read(uint8_t* data) = 0;
-	private:
-		dlistNode_t	list_node;
+		AMF0Base();
+		virtual ~AMF0Base();
+		virtual AMF0Type getType() = 0;
 	};
+
+	template <class T>
+	class AMF0Data : public AMF0Base {
+	public:
+		AMF0Data();
+		virtual ~AMF0Data() {};
+		virtual T getValue() = 0;
+	};
+
+
+	class Iterator : listIter_t {
+	public:
+		Iterator(AMF0*);
+		~Iterator();
+		bool hasNext();
+		AMF0::AMF0Base* getNext();
+		void remove();
+	};
+
 
 	AMF0();
 	virtual ~AMF0();
-	ssize_t serialize(MediaContext* meta, MediaStream* stream);
-	ssize_t deserialize(MediaContext* meta, MediaStream* stream);
-
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
 	ssize_t read(uint8_t* data);
-	void add(AMF0Object* obj);
-	AMF0Object* remove(int idx);
-	int lenght(void);
-	void remove(AMF0Object* obj);
+
+	int add(AMF0Base* obj);
+	void remove(AMF0Base* obj);
+	Iterator* iterator();
+	int length(void);
+private:
+	slistEntry_t immutable_lentry;
+	slistEntry_t mutable_lentry;
+	Iterator* iter;
+};
+
+class AMF0NumberData : public AMF0::AMF0Data<double> {
+public:
+	AMF0NumberData();
+	~AMF0NumberData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	double getValue();
+	AMF0::AMF0Type getType();
+private:
+	double val;
+};
+
+class AMF0BooleanData : public AMF0::AMF0Data<bool> {
+public:
+	AMF0BooleanData();
+	~AMF0BooleanData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	AMF0::AMF0Type getType();
+	bool getValue();
+private:
+	bool val;
+};
+
+class AMF0StringData : public AMF0::AMF0Data<const std::string*> {
+public:
+	AMF0StringData();
+	~AMF0StringData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	AMF0::AMF0Type getType();
+	const std::string* getValue();
+};
+
+class AMF0ObjectData : public AMF0::AMF0Data<const AMF0*> {
+public:
+	AMF0ObjectData();
+	~AMF0ObjectData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	AMF0::AMF0Type getType();
+	const AMF0* getValue();
+};
+
+class AMF0ReferenceData : public AMF0::AMF0Data<uint16_t> {
+public:
+	AMF0ReferenceData();
+	~AMF0ReferenceData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	AMF0::AMF0Type getType();
+	uint16_t getValue();
 
 };
 
+class AMF0ECMAArrayData : public AMF0::AMF0Data<const AMF0*> {
+public:
+	AMF0ECMAArrayData();
+	~AMF0ECMAArrayData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);\
+	AMF0::AMF0Type getType();
+	const AMF0* getValue();
+
+};
+
+class AMF0StrictArrayData : public AMF0::AMF0Data<const AMF0*> {
+public:
+	AMF0StrictArrayData();
+	~AMF0StrictArrayData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	AMF0::AMF0Type getType();
+	const AMF0* getValue();
+
+};
+
+class AMF0DateData : public AMF0::AMF0Data<time_t> {
+public:
+	AMF0DateData();
+	~AMF0DateData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	AMF0::AMF0Type getType();
+	time_t getValue();
+};
+
+class AMF0LongStringData : public AMF0::AMF0Data<const std::string*> {
+public:
+	AMF0LongStringData();
+	~AMF0LongStringData();
+	ssize_t serialize(MediaContext* ctx, MediaStream* stream);
+	ssize_t deserialize(MediaContext* ctx, MediaStream* stream);
+	AMF0::AMF0Type getType();
+	const std::string* getValue();
+};
+
+
+
 
 } /* namespace MediaPipe */
+
+template<class T>
+inline MediaPipe::AMF0::AMF0Data<T>::AMF0Data() {
+}
 
 #endif /* RTMP_AMF0_H_ */

--- a/rtmp/FLVDemuxer.cpp
+++ b/rtmp/FLVDemuxer.cpp
@@ -29,10 +29,5 @@ void FLVDemuxer::parse(size_t vbuf_sz, size_t abuf_sz) {
 
 }
 
-FLVDemuxer::FLVTagHandler::FLVTagHandler() {
-}
-
-FLVDemuxer::FLVTagHandler::~FLVTagHandler() {
-}
 
 } /* namespace MediaPipe */

--- a/rtmp/FLVDemuxer.cpp
+++ b/rtmp/FLVDemuxer.cpp
@@ -10,7 +10,7 @@
 namespace MediaPipe {
 
 FLVDemuxer::FLVDemuxer(MediaStream* stream) {
-	audio_handler = video_handler = script_handler = NULL;
+	videoPayloadHandler = audioPayloadHandler = scriptPayloadHandler = NULL;
 	input_stream = stream;
 }
 
@@ -18,15 +18,12 @@ FLVDemuxer::~FLVDemuxer() {
 	input_stream = NULL;
 }
 
-int FLVDemuxer::setFLVTagHandler(FLVTag::TagType tagType,
-		FLVTagHandler* handler) {
+int FLVDemuxer::setFLVPayloadEventHandler(FLVTag::TagType tagType, PayloadEventHandler<FLVTag>* handler) {
+
 }
 
-void FLVDemuxer::parse(size_t vbuf_sz, size_t abuf_sz) {
-	FLVTag tag = FLVTag();
-	FLVVideoTag vtag = FLVVideoTag(vbuf_sz);
-	FLVAudioTag atag = FLVAudioTag(abuf_sz);
-
+void FLVDemuxer::parse() {
+	FLVTag tag;
 }
 
 

--- a/rtmp/FLVDemuxer.h
+++ b/rtmp/FLVDemuxer.h
@@ -18,8 +18,8 @@ class FLVDemuxer {
 public:
 	class FLVTagHandler {
 	public:
-		FLVTagHandler();
-		virtual ~FLVTagHandler();
+		FLVTagHandler(){};
+		virtual ~FLVTagHandler() {};
 		virtual void onTagHandle(FLVTag* flvTag, FLVPayload* payload) = 0;
 	};
 	FLVDemuxer(MediaStream* input_stream);

--- a/rtmp/FLVDemuxer.h
+++ b/rtmp/FLVDemuxer.h
@@ -16,21 +16,21 @@ namespace MediaPipe {
 
 class FLVDemuxer {
 public:
-	class FLVTagHandler {
+	class FLVPayloadEventHandler : public PayloadEventHandler<FLVTag>{
 	public:
-		FLVTagHandler(){};
-		virtual ~FLVTagHandler() {};
-		virtual void onTagHandle(FLVTag* flvTag, FLVPayload* payload) = 0;
+		FLVPayloadEventHandler(){};
+		virtual ~FLVPayloadEventHandler() {};
+		void onPayload(const Payload<FLVTag>* payload, const MediaStream* stream);
+		void onPayload(const Payload<FLVTag>* payload, const uint8_t* buffer);
 	};
 	FLVDemuxer(MediaStream* input_stream);
 	virtual ~FLVDemuxer();
-	int setFLVTagHandler(FLVTag::TagType tagType, FLVTagHandler* handler);
-	void parse(size_t vb_sz = (1 << 20), size_t ab_sz = (1 << 12));
+	int setFLVPayloadEventHandler(FLVTag::TagType tagType,PayloadEventHandler<FLVTag>* handler);
+	void parse();
 private:
-	FLVTagHandler* video_handler;
-	FLVTagHandler* audio_handler;
-	FLVTagHandler* script_handler;
-
+	FLVPayloadEventHandler* videoPayloadHandler;
+	FLVPayloadEventHandler* audioPayloadHandler;
+	FLVPayloadEventHandler* scriptPayloadHandler;
 	const MediaStream* input_stream;
 };
 

--- a/rtmp/FLVTag.cpp
+++ b/rtmp/FLVTag.cpp
@@ -735,7 +735,6 @@ void FLVVideoTag::setFrameType(FrameType frameType) {
 
 
 FLVDataScriptTag::FLVDataScriptTag() {
-	amf_script = new AMF0();
 }
 
 FLVDataScriptTag::~FLVDataScriptTag() {
@@ -749,7 +748,7 @@ ssize_t FLVDataScriptTag::serialize(MediaContext* ctx,
 	{
 		return -1;
 	}
-	return amf_script->serialize(ctx, stream);
+	return amf_script.serialize(ctx, stream);
 }
 
 ssize_t FLVDataScriptTag::deserialize(MediaContext* ctx, MediaStream* stream) {
@@ -757,7 +756,7 @@ ssize_t FLVDataScriptTag::deserialize(MediaContext* ctx, MediaStream* stream) {
 	{
 		return -1;
 	}
-	return amf_script->deserialize(ctx, stream);
+	return amf_script.deserialize(ctx, stream);
 }
 
 ssize_t FLVDataScriptTag::readData(const MediaContext* ctx, uint8_t* data) {
@@ -765,7 +764,7 @@ ssize_t FLVDataScriptTag::readData(const MediaContext* ctx, uint8_t* data) {
 	{
 		return -1;
 	}
-	return amf_script->read(data);
+	return amf_script.read(data);
 }
 
 MediaPipe::FLVPayload::FLVPayload() { }

--- a/rtmp/FLVTag.h
+++ b/rtmp/FLVTag.h
@@ -195,7 +195,7 @@ public:
 	ssize_t readData(const MediaContext* ctx, uint8_t* data);
 	AMF0* getScriptData(void);
 private:
-	AMF0* amf_script;
+	AMF0 amf_script;
 };
 
 }

--- a/test/rtmp_upstream/rtmp_upstream.cpp
+++ b/test/rtmp_upstream/rtmp_upstream.cpp
@@ -6,10 +6,14 @@
  */
 
 #include "FLVTag.h"
+#include "AMF0.h"
 
 
 int main(void)
 {
-	MediaPipe::FLVTag* flvTag = new MediaPipe::FLVTag();
-	MediaPipe::FLVAudioTag* audio = new MediaPipe::FLVAudioTag(1 << 16);
+	MediaPipe::AMF0* amf0 = new MediaPipe::AMF0();
+	MediaPipe::AMF0BooleanData* bdata = new MediaPipe::AMF0BooleanData();
+	amf0->add(bdata);
+	MediaPipe::AMF0::AMF0Base* base = (MediaPipe::AMF0::AMF0Base*) bdata;
+//	base->serialize(NULL,NULL);
 }

--- a/test/rtmp_upstream/rtmp_upstream.cpp
+++ b/test/rtmp_upstream/rtmp_upstream.cpp
@@ -14,6 +14,5 @@ int main(void)
 	MediaPipe::AMF0* amf0 = new MediaPipe::AMF0();
 	MediaPipe::AMF0BooleanData* bdata = new MediaPipe::AMF0BooleanData();
 	amf0->add(bdata);
-	MediaPipe::AMF0::AMF0Base* base = (MediaPipe::AMF0::AMF0Base*) bdata;
-//	base->serialize(NULL,NULL);
+	MediaPipe::AMF0Base* base = (MediaPipe::AMF0Base*) bdata;
 }


### PR DESCRIPTION
new template class in MediaStream
Packable / Unpackable / Payload are for generic data type to deal with hierarchical characteristics of any protocol. hopefully it can be applied to another protocol. I think it fits to FLV / RTMP well.

java like Iterator / Iterable template for  iteration of any abstract data type(list / tree or something else..)
