### PR TITLE
improve file descriptor management to reflect state of MediaStream subclasses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DBG_UT_TARGET=mpipe_testd_v$(VER_MAJOR).$(VER_MINOR)
 REL_UT_TARGET=mpipe_testr_v$(VER_MAJOR).$(VER_MINOR)
 
 # C++ Flags for release build
-REL_CXXFLAGS :=	-O2 -g -Wall -fmessage-length=0 -pthread
+REL_CXXFLAGS :=	-O2 -g -Wall -fmessage-length=0 -DNDEBUG -pthread
 
 # C++ Flags for Dev build (Note : __DBG Macro can be used to detect build context)
 DBG_CXXFLAGS :=  -O0 -g3 -Wall -fmessage-length=0 -D__DBG -pthread

--- a/core/stream/MediaClientSocketStream.cpp
+++ b/core/stream/MediaClientSocketStream.cpp
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <assert.h>
 
 
 namespace MediaPipe {
@@ -25,16 +26,11 @@ namespace MediaPipe {
 MediaClientSocketStream::MediaClientSocketStream(const char* host, int port) {
 
 	sock_fd = socket(AF_INET, SOCK_STREAM, 0);
-	if(sock_fd < 0) {
-		perror("fail to create socket!!\n");
-		exit(EXIT_FAILURE);
-	}
+	assert(!(sock_fd < 0));
 
 	struct hostent* resolved_host = gethostbyname(host);
-	if(resolved_host == NULL){
-		fprintf(stderr, "fail to resolve hostname : %s!!\n", host);
-		exit(EXIT_FAILURE);
-	}
+	assert(resolved_host);
+
 	memset(&dest_addr, 0, sizeof(dest_addr));
 	dest_addr.sin_family = AF_INET;
 	dest_addr.sin_port = htons(port);
@@ -45,10 +41,7 @@ MediaClientSocketStream::MediaClientSocketStream(const char* host, int port) {
 MediaClientSocketStream::MediaClientSocketStream(int port)
 {
 	sock_fd = socket(AF_INET, SOCK_STREAM, 0);
-	if(sock_fd < 0) {
-		perror("fail to create socket!!\n");
-		exit(EXIT_FAILURE);
-	}
+	assert(!(sock_fd < 0));
 
 	// setup loopback address
 	memset(&dest_addr, 0, sizeof(dest_addr));
@@ -63,56 +56,40 @@ MediaClientSocketStream::~MediaClientSocketStream() {
 
 
 int MediaClientSocketStream::open(void) {
-	if(sock_fd < 0)	{
-		perror("invalid state : socket is not initialized !!\n");
-		exit(EXIT_FAILURE);
-	}
-	int res = ::connect(sock_fd, (const sockaddr*) &dest_addr, sizeof(sockaddr_in));
-	if(res < 0) {
-		perror("fail to connect server !!\n");
-		exit(EXIT_FAILURE);
-	}
+	assert(!(sock_fd < 0));
+	int res = connect(sock_fd, (const sockaddr*) &dest_addr, sizeof(sockaddr_in));
+	assert(!(res < 0));
 	return res;
 }
 
 ssize_t MediaClientSocketStream::read(uint8_t* rb, size_t sz) const {
-	if(sock_fd < 0) {
-		fprintf(stderr, "socket not opened !! \n");
-		exit(1);
-	}
+	assert(!(sock_fd < 0));
 	return recv(sock_fd, rb, sz,0);
 }
 
 char MediaClientSocketStream::read() const {
-	if(sock_fd < 0) {
-		fprintf(stderr, "socket not opened !! \n");
-		exit(1);
-	}
+	assert(!(sock_fd < 0));
 	char c = 0;
 	recv(sock_fd,&c,sizeof(char),0);
 	return c;
 }
 
 ssize_t MediaClientSocketStream::write(const uint8_t* wb, size_t sz) {
-	if(sock_fd < 0) {
-		fprintf(stderr, "socket not opened !! \n");
-		exit(1);
-	}
+	assert(!(sock_fd < 0));
 	return send(sock_fd, wb, sz, 0);
 }
 
 int MediaClientSocketStream::write(const char c) {
-	if(sock_fd < 0) {
-		fprintf(stderr, "socket not opened !! \n");
-		exit(1);
-	}
+	assert(!(sock_fd < 0));
 	return send(sock_fd, &c, sizeof(char),0);
 }
 
 int MediaClientSocketStream::close() {
 	if(sock_fd < 0)
 		return EXIT_FAILURE;
-	return ::close(sock_fd);
+	::close(sock_fd);
+	sock_fd = -1;
+	return EXIT_SUCCESS;
 }
 
 } /* namespace MediaPipe */

--- a/core/stream/MediaFileStream.cpp
+++ b/core/stream/MediaFileStream.cpp
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <assert.h>
 
 namespace MediaPipe {
 
@@ -24,60 +25,42 @@ MediaFileStream::~MediaFileStream() {
 }
 
 int MediaFileStream::open(void) {
-	if(fd >= 0) {
-		::perror("file has already opened !!\n");
-		return EXIT_FAILURE;
-	}
+	assert(!(fd >= 0));
 	fd = ::open(filename.c_str(), O_RDWR);
-	if(fd < 0) {
-		::perror("fail to open file !!\n");
-		::exit(-1);
-	}
+	assert(!(fd < 0));
 	return EXIT_SUCCESS;
 }
 
 ssize_t MediaFileStream::read(uint8_t* rb, size_t sz) const {
-	if(fd < 0) {
-		perror("illegal state : file not opened !! \n");
-		exit(-1);
-	}
+	assert(!(fd < 0));
 	return ::read(fd, rb, sz);
 }
 
 char MediaFileStream::read() const {
-	if(fd < 0) {
-		perror("illegal state : file not opened !! \n");
-		exit(-1);
-	}
+	assert(!(fd < 0));
 	char c = 0;
 	::read(fd, &c, sizeof(char));
 	return c;
 }
 
 ssize_t MediaFileStream::write(const uint8_t* wb, size_t sz) {
-	if(fd < 0) {
-		::perror("illegal state : file not opened !! \n");
-		::exit(-1);
-	}
+	assert(!(fd < 0));
 	return ::write(fd, wb, sz);
 }
 
 int MediaFileStream::write(const char c) {
-	if(fd < 0) {
-		::perror("illegal state : file not opened !! \n");
-		::exit(-1);
-	}
+	assert(!(fd < 0));
 	return ::write(fd, &c, sizeof(char));
 }
 
 int MediaFileStream::close() {
-	if(fd > 0) {
-		return ::close(fd);
-		fd = -1;
+	if(fd < 0){
+		return EXIT_FAILURE;
 	}
+	::close(fd);
+	fd = -1;
 	return EXIT_SUCCESS;
 }
-
 
 
 } /* namespace MediaPipe */

--- a/core/stream/MediaStreamTestUnit.cpp
+++ b/core/stream/MediaStreamTestUnit.cpp
@@ -8,6 +8,7 @@
 #include "MediaStreamTestUnit.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 static void* server_routine(void* arg);
 static void* client_routine(void* arg);
@@ -18,8 +19,9 @@ namespace MediaPipe {
 MediaStreamTestUnit::MediaStreamTestUnit() {
 	client = new MediaClientSocketStream(3030);
 	server = new MediaServerSocketStream(3030);
-	server_thread = {0};
-	client_thread = {0};
+	memset(&server_thread,0,sizeof(pthread_t));
+	memset(&client_thread,0,sizeof(pthread_t));
+
 }
 
 MediaStreamTestUnit::~MediaStreamTestUnit() {
@@ -34,6 +36,7 @@ bool MediaStreamTestUnit::performTest() {
 
 	pthread_join(server_thread,NULL);
 	pthread_join(client_thread,NULL);
+	return TRUE;
 }
 
 } /* namespace MediaPipe */
@@ -44,9 +47,9 @@ static void* server_routine(void* arg)
 	uint8_t msg_buffer[100];
 	MediaPipe::MediaServerSocketStream* server = (MediaPipe::MediaServerSocketStream*) arg;
 	server->open();
-	ssize_t rsz = server->read(msg_buffer,100);
+	server->read(msg_buffer,100);
 	printf("I got a msg :  (%s) from client\n",msg_buffer);
-	server->write(msg_buffer,sprintf((char*) msg_buffer,"Hello Client !!\0"));
+	server->write(msg_buffer,sprintf((char*) msg_buffer,"Hello Client !!"));
 	server->close();
 	return arg;
 }
@@ -56,8 +59,8 @@ static void* client_routine(void* arg)
 	uint8_t msg_buffer[100];
 	MediaPipe::MediaClientSocketStream* client = (MediaPipe::MediaClientSocketStream*) arg;
 	client->open();
-	client->write((const uint8_t*) msg_buffer, sprintf((char*) msg_buffer,"Hello Server !!\0"));
-	ssize_t rsz = client->read(msg_buffer,100);
+	client->write((const uint8_t*) msg_buffer, sprintf((char*) msg_buffer,"Hello Server !!"));
+	client->read(msg_buffer,100);
 	printf("I got a msg : (%s) from server\n",msg_buffer);
 	client->close();
 	return arg;


### PR DESCRIPTION
add file descriptor initialization after file (or socket) closed
 - read / write API checks current state of stream by investigating file descriptor of its own. so putting file descriptor into initial value (e.q. -1) after closing it makes sense to it's state checking mechanism.

use assert api from standard library instead of ad-hoc conditional statement
 - believed to let source code more readable
 - NDEBUG macro variable would be defined in build time (by gnu make) for release build to replace assert into void
