### PR TITLE
refactor FLVTag class & other minor change

### DIFF
--- a/core/MediaDump.cpp
+++ b/core/MediaDump.cpp
@@ -1,0 +1,42 @@
+/*
+ * MediaDump.cpp
+ *
+ *  Created on: May 5, 2016
+ *      Author: innocentevil
+ */
+
+#include "MediaDump.h"
+
+namespace MediaPipe {
+
+MediaDump::MediaDump()
+{
+
+}
+
+MediaDump::~MediaDump()
+{
+}
+
+
+ssize_t MediaDump::serialize(void* ctx, MediaStream* stream)
+{
+
+}
+
+ssize_t MediaDump::serialize(void* ctx, uint8_t* into)
+{
+
+}
+
+ssize_t MediaDump::deserialize(void* ctx, const MediaStream* stream)
+{
+
+}
+
+ssize_t MediaDump::deserialize(void* ctx, const uint8_t* from)
+{
+
+}
+
+} /* namespace MediaPipe */

--- a/core/MediaDump.h
+++ b/core/MediaDump.h
@@ -1,0 +1,33 @@
+/*
+ * MediaDump.h
+ *
+ *  Created on: May 5, 2016
+ *      Author: innocentevil
+ */
+
+#ifndef CORE_MEDIADUMP_H_
+#define CORE_MEDIADUMP_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "MediaStream.h"
+#include "Serialize.h"
+
+namespace MediaPipe {
+
+class MediaDump : public Serializable<void>{
+public:
+	MediaDump();
+	virtual ~MediaDump();
+    ssize_t serialize(void* ctx, MediaStream* stream);
+	ssize_t serialize(void* ctx, uint8_t* into);
+	ssize_t deserialize(void* ctx, const MediaStream* stream);
+	ssize_t deserialize(void* ctx, const uint8_t* from);
+
+};
+
+} /* namespace MediaPipe */
+
+#endif /* CORE_MEDIADUMP_H_ */

--- a/core/Serialize.h
+++ b/core/Serialize.h
@@ -8,6 +8,7 @@
 #ifndef CORE_SERIALIZE_SERIALIZE_H_
 #define CORE_SERIALIZE_SERIALIZE_H_
 
+#include "MediaStream.h"
 
 namespace MediaPipe {
 
@@ -20,39 +21,6 @@ public:
 	virtual ssize_t serialize(T* ctx, uint8_t* into) = 0;
 	virtual ssize_t deserialize(T* ctx, const MediaStream* stream) = 0;
 	virtual ssize_t deserialize(T* ctx, const uint8_t* from) = 0;
-};
-
-
-template <class T>
-class Payload : Serializable<T> {
-public:
-	Payload(){};
-	virtual ~Payload(){};
-};
-
-template <class T>
-class PayloadEventHandler {
-public:
-	PayloadEventHandler() {};
-	virtual ~PayloadEventHandler(){};
-	virtual void onPayload(const Payload<T>* payload,const MediaStream* stream);
-	virtual void onPayload(const Payload<T>* payload,const uint8_t* buffer);
-};
-
-template <class T>
-class Unpackable {
-public:
-	Unpackable() {};
-	virtual ~Unpackable() {};
-	virtual Payload<T>* getPayload() = 0;
-};
-
-template <class T>
-class Packable {
-public:
-	Packable() {};
-	virtual ~Packable(){};
-	virtual bool setPayload(const Payload<T>* payload) = 0;
 };
 
 

--- a/core/recipe.mk
+++ b/core/recipe.mk
@@ -1,4 +1,4 @@
 INC-$(CONFIG_CORE)+=./core 
 SRC-$(CONFIG_CORE)+=./core
 # add object to be built
- 
+OBJ-$(CONFIG_CORE)+= MediaDump

--- a/rtmp/AMF0.cpp
+++ b/rtmp/AMF0.cpp
@@ -12,6 +12,8 @@
 #include "Iterator.h"
 #include "AMF0.h"
 #include "FLVTag.h"
+
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>

--- a/rtmp/AMF0.h
+++ b/rtmp/AMF0.h
@@ -10,8 +10,10 @@
 #define RTMP_AMF0_H_
 
 #include <string>
+#include <mutex>
 #include <stdint.h>
 #include <pthread.h>
+
 #include "Iterator.h"
 #include "core/MediaStream.h"
 #include "core/Serialize.h"

--- a/rtmp/FLVDemuxer.cpp
+++ b/rtmp/FLVDemuxer.cpp
@@ -19,11 +19,22 @@ FLVDemuxer::~FLVDemuxer() {
 }
 
 int FLVDemuxer::setFLVPayloadEventHandler(FLVTag::TagType tagType, PayloadEventHandler<FLVTag>* handler) {
-
+	switch(tagType) {
+	case FLVTag::Audio:
+		videoPayloadHandler = (FLVPayloadEventHandler*) handler;
+		break;
+	case FLVTag::Video:
+		audioPayloadHandler = (FLVPayloadEventHandler*) handler;
+		break;
+	case FLVTag::Script:
+		scriptPayloadHandler = (FLVPayloadEventHandler*) handler;
+		break;
+	}
 }
 
 void FLVDemuxer::parse() {
 	FLVTag tag;
+	tag.deserialize(NULL, input_stream);
 }
 
 

--- a/rtmp/FLVDemuxer.cpp
+++ b/rtmp/FLVDemuxer.cpp
@@ -10,7 +10,6 @@
 namespace MediaPipe {
 
 FLVDemuxer::FLVDemuxer(MediaStream* stream) {
-	videoPayloadHandler = audioPayloadHandler = scriptPayloadHandler = NULL;
 	input_stream = stream;
 }
 
@@ -18,23 +17,29 @@ FLVDemuxer::~FLVDemuxer() {
 	input_stream = NULL;
 }
 
-int FLVDemuxer::setFLVPayloadEventHandler(FLVTag::TagType tagType, PayloadEventHandler<FLVTag>* handler) {
-	switch(tagType) {
-	case FLVTag::Audio:
-		videoPayloadHandler = (FLVPayloadEventHandler*) handler;
-		break;
-	case FLVTag::Video:
-		audioPayloadHandler = (FLVPayloadEventHandler*) handler;
-		break;
-	case FLVTag::Script:
-		scriptPayloadHandler = (FLVPayloadEventHandler*) handler;
-		break;
+int FLVDemuxer::parse() {
+	FLVTag commonTag;
+	FLVVideoTag videoTag;
+	FLVAudioTag audioTag;
+	FLVDataScriptTag scriptTag;
+	while(commonTag.deserialize(NULL, input_stream) > 0)
+	{
+		switch(commonTag.getType()) {
+		case FLVTag::Audio:
+			if(audioTag.deserialize(&commonTag, input_stream) < 0)
+				return -1;
+			break;
+		case FLVTag::Video:
+			if(videoTag.deserialize(&commonTag, input_stream) < 0)
+				return -1;
+			break;
+		case FLVTag::Script:
+			if(scriptTag.deserialize(&commonTag, input_stream) < 0)
+				return -1;
+			break;
+		}
 	}
-}
-
-void FLVDemuxer::parse() {
-	FLVTag tag;
-	tag.deserialize(NULL, input_stream);
+	return 0;
 }
 
 

--- a/rtmp/FLVDemuxer.h
+++ b/rtmp/FLVDemuxer.h
@@ -16,21 +16,10 @@ namespace MediaPipe {
 
 class FLVDemuxer {
 public:
-	class FLVPayloadEventHandler : public PayloadEventHandler<FLVTag>{
-	public:
-		FLVPayloadEventHandler(){};
-		virtual ~FLVPayloadEventHandler() {};
-		void onPayload(const Payload<FLVTag>* payload, const MediaStream* stream);
-		void onPayload(const Payload<FLVTag>* payload, const uint8_t* buffer);
-	};
 	FLVDemuxer(MediaStream* input_stream);
 	virtual ~FLVDemuxer();
-	int setFLVPayloadEventHandler(FLVTag::TagType tagType,PayloadEventHandler<FLVTag>* handler);
-	void parse();
+	int parse();
 private:
-	FLVPayloadEventHandler* videoPayloadHandler;
-	FLVPayloadEventHandler* audioPayloadHandler;
-	FLVPayloadEventHandler* scriptPayloadHandler;
 	const MediaStream* input_stream;
 };
 

--- a/rtmp/FLVTag.h
+++ b/rtmp/FLVTag.h
@@ -17,7 +17,7 @@
 
 namespace MediaPipe {
 
-class FLVTag : Serializable<void>, public Unpackable<FLVTag> , public Packable<FLVTag> {
+class FLVTag : Serializable<void>{
 public:
 	FLVTag();
 	virtual ~FLVTag();
@@ -31,9 +31,6 @@ public:
 	ssize_t serialize(void* ctx, uint8_t* into);
 	ssize_t deserialize(void* ctx, const MediaStream* stream);
 	ssize_t deserialize(void* ctx, const uint8_t* from);
-
-	Payload<FLVTag>* getPayload();
-	bool setPayload(const Payload<FLVTag>* payload);
 
 	TagType getType(void) const;
 	void setType(TagType);
@@ -50,9 +47,9 @@ private:
 	TagType  type;				// video / audio / datascript
 };
 
-class FLVVideoTag : public Payload<FLVTag> , public Unpackable<FLVVideoTag>, public Packable<FLVVideoTag> {
+class FLVVideoTag : public Serializable<FLVTag> {
 public:
-	FLVVideoTag(size_t bsz);
+	FLVVideoTag();
 	~FLVVideoTag();
 
 	typedef enum {
@@ -84,16 +81,6 @@ public:
 	ssize_t deserialize(FLVTag* ctx, const MediaStream* stream);
 	ssize_t deserialize(FLVTag* ctx, const uint8_t* from);
 
-	Payload<FLVVideoTag>* getPayload();
-	bool setPayload(const Payload<FLVVideoTag>* payload);
-
-	/*
-	 * in some sense, set payload method overlaps functionality on write method below
-	 * but I can't be sure which will be more elegant for whole design.
-	 */
-	ssize_t writeDataAVC(FLVTag* ctx, uint8_t* data, size_t sz, FrameType, CodecID, AVCPktType, uint32_t dts, uint32_t pts);
-	ssize_t writeData(FLVTag* ctx, uint8_t* data, size_t sz, FrameType, CodecID, uint32_t dts, uint32_t pts);
-	ssize_t writeData(FLVTag* ctx, uint8_t* data, size_t sz,  uint32_t dts, uint32_t pts);
 
 	AVCPktType getAvcType() const;
 	void setAvcType(AVCPktType avcType);
@@ -106,13 +93,12 @@ private:
 	FrameType frame_type;		// FrameType (Key Frame / Interframe and so on...)
 	CodecID codec_id;			// Codec ID  (H.263 / H.264 and so on...)
 	AVCPktType avc_type;		// AVC Chunk Specifier (Sequence header / nalu)
-	uint8_t* obj_buffer;
 	uint32_t cts;				// composition time stamp which eventually (pts - dts) in millisec
 };
 
-class FLVAudioTag :  Payload<FLVTag>, public Unpackable<FLVAudioTag> , public Packable<FLVAudioTag> {
+class FLVAudioTag :  Serializable<FLVTag> {
 public:
-	FLVAudioTag(size_t bsz);
+	FLVAudioTag();
 	~FLVAudioTag();
 
 	typedef enum {
@@ -158,19 +144,6 @@ public:
 	ssize_t deserialize(FLVTag* ctx, const MediaStream* stream);
 	ssize_t deserialize(FLVTag* ctx, const uint8_t* from);
 
-	Payload<FLVAudioTag>* getPayload();
-	bool setPayload(const Payload<FLVAudioTag>* );
-
-	/**
-	 *  write audio data into flv chunk
-	 *  @param ctx MediaContext(FLVTag here) to be updated by the audio raw data
-	 *  @param data audio data buffer to be written
-	 *  @param size size of audio data
-	 *  @param
-	 */
-	ssize_t writeData(FLVTag* ctx, uint8_t* data, size_t sz, SoundFormat fmt, SoundRate rate, SoundSize smp_sz, SoundType snd_type, uint32_t timestamp);
-	ssize_t writeDataAAC(FLVTag* ctx, uint8_t* data, size_t sz, SoundRate, SoundSize, SoundType, AACPktType, uint32_t timestamp);
-	ssize_t writeData(FLVTag* ctx, uint8_t* data, size_t sz, uint32_t timestamp);
 
 	void setSoundFormat(SoundFormat fmt);
 	SoundFormat getSoundFormat(void) const;
@@ -190,10 +163,9 @@ private:
 	SoundType snd_type;
 	SoundSize snd_sz;
 	AACPktType aac_pkt_type;
-	uint8_t* obj_buffer;
 };
 
-class FLVDataScriptTag : Payload<FLVTag>  {
+class FLVDataScriptTag : Serializable<FLVTag>  {
 public:
 	FLVDataScriptTag();
 	~FLVDataScriptTag();
@@ -202,10 +174,6 @@ public:
 	ssize_t serialize(FLVTag* ctx, uint8_t* into);
 	ssize_t deserialize(FLVTag* ctx, const MediaStream* stream);
 	ssize_t deserialize(FLVTag* ctx, const uint8_t* from);
-
-	AMF0* getScriptData(void);
-private:
-	AMF0 amf_script;
 };
 
 }

--- a/rtmp/FLVTestUnit.cpp
+++ b/rtmp/FLVTestUnit.cpp
@@ -1,0 +1,24 @@
+/*
+ * FLVTestUnit.cpp
+ *
+ *  Created on: May 1, 2016
+ *      Author: innocentevil
+ */
+
+#include "FLVTestUnit.h"
+
+namespace MediaPipe {
+
+FLVTestUnit::FLVTestUnit() {
+
+}
+
+FLVTestUnit::~FLVTestUnit() {
+}
+
+bool FLVTestUnit::performTest() {
+
+}
+
+
+} /* namespace MediaPipe */

--- a/rtmp/FLVTestUnit.h
+++ b/rtmp/FLVTestUnit.h
@@ -1,0 +1,23 @@
+/*
+ * FLVTestUnit.h
+ *
+ *  Created on: May 1, 2016
+ *      Author: innocentevil
+ */
+
+#ifndef RTMP_FLVTESTUNIT_H_
+#define RTMP_FLVTESTUNIT_H_
+
+namespace MediaPipe {
+
+class FLVTestUnit {
+public:
+	FLVTestUnit();
+	virtual ~FLVTestUnit();
+	bool performTest();
+private:
+};
+
+} /* namespace MediaPipe */
+
+#endif /* RTMP_FLVTESTUNIT_H_ */

--- a/rtmp/README.md
+++ b/rtmp/README.md
@@ -1,0 +1,1 @@
+## RTMP Protocol overview


### PR DESCRIPTION
1. refactor FLVTag class
  - for better modular characteristic, FLVTag should be
  agnostic to its payload type. so I decided to separate
  payload parsing from FLVTag.
  - payload of FLVTag is low level media binary mostly
  used by decoder (like h264, 263). so implement
  payload parser inside of FLVTag is not good design
  decision because it make FLVTag even bigger and
  complicated.
  - docoder / encoder can be provided which is pluggable to
  mpipe de / serialize API. by doing this, I hope transcoding
  can be dealt with more simple & modular fashion.

2. add MediaDump class for consuming uninterested media chunk
  - MediaDemuxer like FLVDemuxer provides callback based payload
  handling. so if there is no callback for specific media chunk,
  it should be skipped.
  - in some case, application needs to store media payload as
  as-is binary image(so called dump).

3. remove payload class and its sibling.
  - it has caused bad-design for pipelining concept.